### PR TITLE
Add celebratory confetti overlay when games complete

### DIFF
--- a/src/components/ConfettiCelebration.tsx
+++ b/src/components/ConfettiCelebration.tsx
@@ -1,0 +1,89 @@
+import { type CSSProperties, useEffect, useMemo, useState } from 'react'
+
+const CONFETTI_COLORS = [
+  '#f97316',
+  '#f59e0b',
+  '#34d399',
+  '#38bdf8',
+  '#a855f7',
+  '#ef4444',
+  '#22d3ee',
+  '#facc15',
+]
+
+const PIECE_COUNT = 180
+const MAX_DURATION = 6
+const MIN_DURATION = 3.5
+
+interface ConfettiPiece {
+  id: number
+  left: number
+  delay: number
+  duration: number
+  drift: number
+  rotateStart: number
+  rotateEnd: number
+  size: number
+  heightFactor: number
+  color: string
+  borderRadius: string
+}
+
+export function ConfettiCelebration() {
+  const [isActive, setIsActive] = useState(true)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setIsActive(false), MAX_DURATION * 1000)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  const pieces = useMemo<ConfettiPiece[]>(() => {
+    const randomBetween = (min: number, max: number) =>
+      Math.random() * (max - min) + min
+
+    return Array.from({ length: PIECE_COUNT }, (_, index) => {
+      const size = randomBetween(4, 10)
+      return {
+        id: index,
+        left: randomBetween(0, 100),
+        delay: randomBetween(0, 1.8),
+        duration: randomBetween(MIN_DURATION, MAX_DURATION),
+        drift: randomBetween(-120, 120),
+        rotateStart: randomBetween(0, 360),
+        rotateEnd: randomBetween(720, 1440),
+        size,
+        heightFactor: randomBetween(0.7, 1.6),
+        color: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+        borderRadius: Math.random() > 0.7 ? '999px' : '4px',
+      }
+    })
+  }, [])
+
+  if (!isActive) {
+    return null
+  }
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-[60] overflow-hidden"
+      aria-hidden="true"
+    >
+      {pieces.map((piece) => {
+        const style: CSSProperties & Record<string, string> = {
+          left: `${piece.left}%`,
+          width: `${piece.size}px`,
+          height: `${piece.size * piece.heightFactor}px`,
+          backgroundColor: piece.color,
+          borderRadius: piece.borderRadius,
+          animationDelay: `${piece.delay}s`,
+          animationDuration: `${piece.duration}s`,
+          '--confetti-drift': `${piece.drift}px`,
+          '--confetti-rotate-start': `${piece.rotateStart}deg`,
+          '--confetti-rotate-end': `${piece.rotateEnd}deg`,
+        }
+
+        return <span key={piece.id} className="confetti-piece" style={style} />
+      })}
+    </div>
+  )
+}

--- a/src/components/GameView.tsx
+++ b/src/components/GameView.tsx
@@ -48,6 +48,7 @@ import {
 import { useNavigate } from 'react-router-dom'
 import { AddPlayersToGame } from './AddPlayersToGame'
 import { FullscreenVideoPlayer } from './FullscreenVideoPlayer'
+import { ConfettiCelebration } from './ConfettiCelebration'
 
 // Using GameViewProps from types/index.ts
 
@@ -227,80 +228,83 @@ export function GameView({ gameId, onBack }: GameViewProps) {
   if (game.status === 'completed') {
     const winner = game.participants.find((p) => p.playerId === game.winner)
     return (
-      <div className="rounded-lg border p-8 text-center shadow-sm">
-        <h1 className="mb-4 text-4xl font-bold text-green-600">
-          🏆 Game Complete!
-        </h1>
-        <h2 className="text-foreground mb-2 text-2xl font-semibold">
-          {winner?.player?.name} Wins!
-        </h2>
-        <p className="text-foreground/70 mb-6 text-lg">
-          Final Score: {winner?.currentPoints} / {game.winningPoints} points
-        </p>
+      <div className="relative">
+        <ConfettiCelebration />
+        <div className="rounded-lg border p-8 text-center shadow-sm">
+          <h1 className="mb-4 text-4xl font-bold text-green-600">
+            🏆 Game Complete!
+          </h1>
+          <h2 className="text-foreground mb-2 text-2xl font-semibold">
+            {winner?.player?.name} Wins!
+          </h2>
+          <p className="text-foreground/70 mb-6 text-lg">
+            Final Score: {winner?.currentPoints} / {game.winningPoints} points
+          </p>
 
-        <div className="rounded-lg p-6">
-          <h3 className="text-foreground mb-4 text-lg font-semibold">
-            Final Standings
-          </h3>
-          <div className="space-y-2">
-            {game.participants
-              .sort((a, b) => b.currentPoints - a.currentPoints)
-              .map((participant, index) => (
-                <div
-                  key={participant.playerId}
-                  className="flex items-center justify-between rounded border p-3"
-                >
-                  <div className="flex items-center space-x-3">
-                    <span className="text-foreground/50 text-lg font-bold">
-                      #{index + 1}
-                    </span>
-                    <span className="font-medium">
-                      {participant.player?.name}
+          <div className="rounded-lg p-6">
+            <h3 className="text-foreground mb-4 text-lg font-semibold">
+              Final Standings
+            </h3>
+            <div className="space-y-2">
+              {game.participants
+                .sort((a, b) => b.currentPoints - a.currentPoints)
+                .map((participant, index) => (
+                  <div
+                    key={participant.playerId}
+                    className="flex items-center justify-between rounded border p-3"
+                  >
+                    <div className="flex items-center space-x-3">
+                      <span className="text-foreground/50 text-lg font-bold">
+                        #{index + 1}
+                      </span>
+                      <span className="font-medium">
+                        {participant.player?.name}
+                      </span>
+                    </div>
+                    <span className="text-lg font-semibold">
+                      {participant.currentPoints} pts
                     </span>
                   </div>
-                  <span className="text-lg font-semibold">
-                    {participant.currentPoints} pts
-                  </span>
-                </div>
-              ))}
-          </div>
-        </div>
-
-        <div className="mt-8 flex flex-col items-center space-y-4">
-          {!game.leagueId && (
-            <div className="text-center">
-              <p className="text-foreground/70 mb-4 text-sm">
-                Want to play again with the same players?
-              </p>
-              <Button
-                onClick={handleNewGameWithSamePlayers}
-                disabled={isCreatingNewGame}
-                size="lg"
-                className="px-8 py-3"
-              >
-                <Play className="mr-2 h-5 w-5" />
-                {isCreatingNewGame
-                  ? 'Creating...'
-                  : 'New Game with Same Players'}
-              </Button>
+                ))}
             </div>
-          )}
-          <Button
-            variant="outline"
-            onClick={() => {
-              if (isLeagueGame && leagueId) {
-                // For league games accessed through league route, go back to league
-                navigate(`/league/${leagueId}`)
-              } else {
-                // For standalone games, go back to games list
-                navigate('/games')
-              }
-            }}
-            size="sm"
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            {isLeagueGame ? 'Back to League' : 'Back to Games'}
-          </Button>
+          </div>
+
+          <div className="mt-8 flex flex-col items-center space-y-4">
+            {!game.leagueId && (
+              <div className="text-center">
+                <p className="text-foreground/70 mb-4 text-sm">
+                  Want to play again with the same players?
+                </p>
+                <Button
+                  onClick={handleNewGameWithSamePlayers}
+                  disabled={isCreatingNewGame}
+                  size="lg"
+                  className="px-8 py-3"
+                >
+                  <Play className="mr-2 h-5 w-5" />
+                  {isCreatingNewGame
+                    ? 'Creating...'
+                    : 'New Game with Same Players'}
+                </Button>
+              </div>
+            )}
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (isLeagueGame && leagueId) {
+                  // For league games accessed through league route, go back to league
+                  navigate(`/league/${leagueId}`)
+                } else {
+                  // For standalone games, go back to games list
+                  navigate('/games')
+                }
+              }}
+              size="sm"
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {isLeagueGame ? 'Back to League' : 'Back to Games'}
+            </Button>
+          </div>
         </div>
       </div>
     )

--- a/src/index.css
+++ b/src/index.css
@@ -141,3 +141,36 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  .confetti-piece {
+    position: absolute;
+    top: -12vh;
+    opacity: 0;
+    will-change: transform, opacity;
+    transform-origin: left top;
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.05);
+    transform: rotate(var(--confetti-rotate-start, 0deg));
+    animation-name: confetti-fall;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
+  }
+}
+
+@layer base {
+  @keyframes confetti-fall {
+    0% {
+      transform: translate3d(0, -10vh, 0)
+        rotate(var(--confetti-rotate-start, 0deg));
+      opacity: 0;
+    }
+    10% {
+      opacity: 1;
+    }
+    100% {
+      transform: translate3d(var(--confetti-drift, 0px), 110vh, 0)
+        rotate(var(--confetti-rotate-end, 720deg));
+      opacity: 0;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce [ConfettiCelebration](http://_vscodecontentref_/0) for a lightweight, self-contained confetti animation that auto-expires after a short burst
- wire the celebration overlay into the completed state of [GameView](http://_vscodecontentref_/1) so every finished game gets a visual win moment
- extend the global stylesheet with the animation keyframes and utility styles used by the confetti pieces

## Visuals
- 🎥 (optional) Record a short clip of finishing a game to showcase the confetti burst

## Testing
- npm run build

## Rollout / QA Notes
- no config changes required; the effect triggers automatically when [game.status === "completed"](http://_vscodecontentref_/2)
- animation is ephemeral and unmounts after ~6 seconds, so it won’t affect subsequent navigation

## Follow-ups
- consider adding a unit/integration test around the completed-game branch once test infra exists
- could revisit chunk warnings separately if we decide to split bundles