### PR TITLE
Add MIT license and document it in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Slap It contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Check out the [Convex docs](https://docs.convex.dev/) for more information on ho
 ## HTTP API
 
 User-defined http routes are defined in the `convex/router.ts` file. We split these routes into a separate file from `convex/http.ts` to allow us to prevent the LLM from modifying the authentication routes.
+
+## License
+
+This project is licensed under the terms of the [MIT License](./LICENSE).


### PR DESCRIPTION
## Overview
This change formalizes the project’s open-source status. A new `LICENSE` file contains the MIT terms so downstream users and contributors have clear legal footing. The `README.md` now links directly to the license for quick visibility.

## Motivation
The repository previously lacked an explicit license, which can block adoption or contributions because the legal permissions are unclear. Adding an MIT license provides a permissive framework favored for community-driven projects and commercial reuse alike.

## Changes
- Add the full MIT License text in a new top-level `LICENSE` file.
- Update `README.md` with a "License" section that links to the newly added file.

## Testing
- Not run (documentation-only change).

## Risks & Mitigations
- Very low risk; runtime code is untouched, so builds and deployments are unaffected.

## Follow-up Considerations
- If a different license is desired later, replace the license text and adjust the README link accordingly.
- Consider adding a CONTRIBUTING guide to complement the new license.