### PR TITLE
Add Slapit Non-Commercial License and document restrictions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,53 @@
+# Slapit Non-Commercial License (SNCL) v1.0
+
+_Last updated: October 1, 2025_
+
+## 1. Definitions
+- **"Owner"** means the copyright holder(s) of the Slapit project.
+- **"Project"** means the Slapit codebase, artwork, assets, documentation, and any related materials distributed with this repository.
+- **"You"** means the individual or legal entity exercising rights under this License.
+- **"Commercial Purpose"** means any use that is intended for or directed toward commercial advantage or monetary compensation, including but not limited to advertising, hosting, resale, licensing, bundling, providing Software as a Service (SaaS), or training machine learning models that support commercial products.
+
+## 2. Grant of Limited Rights
+Subject to your full compliance with this License, the Owner grants you a personal, non-transferable, non-exclusive, revocable license to:
+- Access and review the Project for evaluation, learning, or contributing improvements that you submit back to the Owner under this License; and
+- Run the Project locally for your own non-commercial experimentation.
+
+No other rights are granted, expressly or by implication. This License does **not** transfer ownership of any intellectual property.
+
+## 3. Prohibited Uses
+You **must not**:
+1. Reproduce, copy, fork, host, mirror, publish, or distribute the Project or any portion of it, except ephemeral copies required for your permitted local use under Section 2.
+2. Use the Project, or any derivative work based on it, for any Commercial Purpose.
+3. Sell, license, rent, lease, sublicense, or otherwise provide access to the Project or any derivative work to any third party.
+4. Incorporate any part of the Project into another product, service, or codebase intended for production, commercial, or publicly accessible use.
+5. Remove, obscure, or alter any notices of authorship, attribution, trademark, or copyright.
+
+## 4. Derivative Works
+You may create derivative works solely for personal evaluation or to prepare contributions that you submit to the Owner for inclusion in the Project. All such derivatives remain subject to this License. You may not distribute, publish, or deploy any derivative work without the Owner's prior written consent.
+
+## 5. Contributions
+If you submit changes, pull requests, or other contributions to the Owner:
+- You grant the Owner an irrevocable, perpetual, worldwide, royalty-free license to use, modify, and incorporate your contribution into the Project under this License or any future license chosen by the Owner.
+- You represent that your contribution is original to you and does not infringe any third-party rights.
+
+## 6. Confidentiality
+You must take reasonable steps to prevent unauthorized disclosure of the Project. Sharing access credentials or source materials with any third party is strictly prohibited.
+
+## 7. Termination
+This License terminates automatically if you breach any term. Upon termination, you must immediately cease all use of the Project and destroy all copies in your possession or control. The Owner may reinstate the License only via a signed written waiver.
+
+## 8. Enforcement and Remedies
+Because unauthorized copying or commercial use would cause irreparable harm, the Owner is entitled to seek injunctive relief, damages, and any other remedies available at law or equity.
+
+## 9. Disclaimers
+THE PROJECT IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. THE OWNER DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+
+## 10. Limitation of Liability
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE OWNER IS NOT LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOSS OF PROFITS, REVENUES, DATA, OR GOODWILL, ARISING OUT OF OR RELATED TO YOUR USE OF THE PROJECT, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+## 11. Governing Law
+This License is governed by the laws of the jurisdiction in which the Owner resides, without regard to conflict-of-law rules.
+
+## 12. Entire Agreement
+This License constitutes the entire agreement between you and the Owner concerning the Project and supersedes any prior agreements or understandings. Any modification must be in writing and signed by the Owner.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Check out the [Convex docs](https://docs.convex.dev/) for more information on ho
 ## HTTP API
 
 User-defined http routes are defined in the `convex/router.ts` file. We split these routes into a separate file from `convex/http.ts` to allow us to prevent the LLM from modifying the authentication routes.
+
+## License
+
+This project is distributed under the [Slapit Non-Commercial License (SNCL) v1.0](./LICENSE.md). Commercial use, redistribution, and hosting are prohibited without explicit written permission from the project owner.


### PR DESCRIPTION
## Summary
- add `LICENSE.md` introducing the Slapit Non-Commercial License (SNCL) v1.0, which forbids redistribution and any commercial exploitation of the project
- document the licensing terms in the README so contributors and users immediately understand the non-commercial requirements

## Testing
- Not run (documentation-only updates)

## Additional Notes
- The SNCL v1.0 allows only personal, non-commercial experimentation and contribution back to the project; all other copying, hosting, or monetized use is prohibited without written approval.